### PR TITLE
Do not default to destroying the pool when exporting it

### DIFF
--- a/gui/storage/models.py
+++ b/gui/storage/models.py
@@ -271,7 +271,7 @@ class Volume(Model):
         return (reload_cifs, reload_afp, reload_nfs, reload_iscsi,
                 reload_jails, reload_collectd)
 
-    def _delete(self, destroy=True, cascade=True, systemdataset=None):
+    def _delete(self, destroy=False, cascade=True, systemdataset=None):
         """
         Some places reference a path which will not cascade delete
         We need to manually find all paths within this volume mount point
@@ -349,7 +349,7 @@ class Volume(Model):
 
         return (svcs, reloads)
 
-    def delete(self, destroy=True, cascade=True):
+    def delete(self, destroy=False, cascade=True):
         from freenasUI.system.models import SystemDataset
 
         try:


### PR DESCRIPTION
When the pool is exported via the UI, volume_detach() calls volume.delete() with the parameters, the destroy= parameter is controlled by the 'mark_new' form field as expected.

However, when trying to IMPORT a pool, if there is an exception in volume_import() (in the case of a GELI error for example), the exception handler loops over all objects in 'model_objs' and calls their delete() method with no parameters. In the method definition, Volume.delete() defaults the destroy parameter to True. So instead of exporting the pool in the case of an exception during import, it destroys the pool. It even goes so far as to invoke 'geli clear' on each disk, destroying the encryption metadata required to re-attach the disks.

FreeNAS's UI should probably also allow the user to backup this metadata (geli backup provider filename) in addition to the key files.

Exception that lead to this discovery: https://redmine.ixsystems.com/issues/26834
Exception Type: IntegrityError
Exception Value:
UNIQUE constraint failed: storage_encrypteddisk.encrypted_provider
Exception Location: ./freenasUI/freeadmin/sqlite3_ha/base.py in locked_retry, line 389


The exception handling that lead to this was introduced on May 24th 2017: https://github.com/freenas/freenas/commit/35c5cd3baa4f09a75acb9d9111bdf9b4bcb4f9a1

But the problem is the default, not the way the exception is handled.